### PR TITLE
Allow manually approve and publish each new ad paid

### DIFF
--- a/pagseguro-classipress-gateway.php
+++ b/pagseguro-classipress-gateway.php
@@ -157,12 +157,19 @@ function pagseguro_create_payment_listener() {
 
 		switch ( $status ) {
 			case 3:
-				if ( $order->get_status() == 'tr_activated' ) {
+				if ( $order->get_status() == 'tr_activated' || $order->get_status() == 'tr_completed' ) {
 					pagseguro_log( 'Notificação repetida para ' . $transaction->reference . '. Ignorando...' );
 
 					return;
 				}
-				$order->activate();
+
+                                global $cp_options;
+                                if ( $cp_options->moderate_ads ) {
+                                        $order->complete();
+                                }else{
+                                        $order->activate();
+                                }
+
 				pagseguro_log( 'Pedido ' . $transaction->reference . ' foi ativado');
 				break;
 			case 7:


### PR DESCRIPTION
A opção de moderar anúncios não estava sendo considerada, portanto ao realizar o pagamento via pagseguro o anúncio era publicado automaticamente.